### PR TITLE
no longer discarding first coverage result

### DIFF
--- a/src/parse-lcov.ts
+++ b/src/parse-lcov.ts
@@ -111,8 +111,6 @@ function walkFile(str: string): Promise<CoverageCollection> {
       }
     }
 
-    data.shift();
-
     if (data.length) {
       resolve(data);
     } else {


### PR DESCRIPTION
The change in https://github.com/markis/vscode-code-coverage/blob/77aa7500c84ea8c2d027159a1d610f692ea9d818/src/parse-lcov.ts#L91 made https://github.com/markis/vscode-code-coverage/blob/77aa7500c84ea8c2d027159a1d610f692ea9d818/src/parse-lcov.ts#L114 discard the first coverage result.

Removing `data.shift();` call to fix.