### PR TITLE
remove old diagnostics for files without new diagnostic messages

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,12 +32,12 @@ export function activate(context: ExtensionContext) {
   workspace.onDidChangeTextDocument(e => {
     if (e) {
       diagnostics.delete(e.document.uri);
-      showStatus(e.document.uri.fsPath);
+      showStatus();
     }
   });
   workspace.onDidOpenTextDocument(e => {
     if (e) {
-      showStatus(e.fileName);
+      showStatus();
     }
   });
   workspace.onDidCloseTextDocument(() => {
@@ -47,7 +47,7 @@ export function activate(context: ExtensionContext) {
   });
   window.onDidChangeActiveTextEditor(e => {
     if (e) {
-      showStatus(e.document.fileName);
+      showStatus();
     }
   });
 
@@ -66,8 +66,12 @@ export function activate(context: ExtensionContext) {
       });
   }
 
-  function showStatus(file: string) {
-    file = file.toLowerCase();
+  function showStatus() {
+    const activeTextEditor = window.activeTextEditor;
+    if (!activeTextEditor) {
+      return;
+    }
+    const file: string = activeTextEditor.document.uri.fsPath.toLowerCase();
     if (coverageByfile.has(file)) {
       const coverage = coverageByfile.get(file);
       if (coverage) {
@@ -77,10 +81,7 @@ export function activate(context: ExtensionContext) {
         statusBar.show();
       }
     } else {
-      const activeTextEditor = window.activeTextEditor;
-      if (activeTextEditor && (activeTextEditor.document.uri.fsPath.toLowerCase() === file)) {
-        statusBar.hide ();
-      }
+      statusBar.hide ();
     }
   }
 
@@ -89,10 +90,7 @@ export function activate(context: ExtensionContext) {
     for (const coverage of coverages) {
       coverageByfile.set(coverage.file.toLowerCase(), coverage);
     }
-    const activeTextEditor = window.activeTextEditor;
-    if (activeTextEditor) {
-      showStatus(activeTextEditor.document.uri.fsPath);
-    }
+    showStatus();
   }
 
   function convertDiagnostics(coverages: CoverageCollection) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -79,7 +79,7 @@ export function activate(context: ExtensionContext) {
     } else {
       const activeTextEditor = window.activeTextEditor;
       if (activeTextEditor && (activeTextEditor.document.uri.fsPath.toLowerCase() === file)) {
-        statusBar.text = "";
+        statusBar.hide ();
       }
     }
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -96,6 +96,8 @@ export function activate(context: ExtensionContext) {
 
         if (diagnosticsForFiles.length > 0) {
           diagnostics.set(Uri.file(coverage.file), diagnosticsForFiles);
+        } else {
+          diagnostics.delete(Uri.file(coverage.file));
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,20 +35,14 @@ export function activate(context: ExtensionContext) {
       showStatus();
     }
   });
-  workspace.onDidOpenTextDocument(e => {
-    if (e) {
-      showStatus();
-    }
+  workspace.onDidOpenTextDocument(() => {
+    showStatus();
   });
   workspace.onDidCloseTextDocument(() => {
-    if (!window.activeTextEditor) {
-      statusBar.hide();
-    }
+    showStatus();
   });
-  window.onDidChangeActiveTextEditor(e => {
-    if (e) {
-      showStatus();
-    }
+  window.onDidChangeActiveTextEditor(() => {
+    showStatus();
   });
 
   findDiagnostics();
@@ -69,6 +63,7 @@ export function activate(context: ExtensionContext) {
   function showStatus() {
     const activeTextEditor = window.activeTextEditor;
     if (!activeTextEditor) {
+      statusBar.hide();
       return;
     }
     const file: string = activeTextEditor.document.uri.fsPath.toLowerCase();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,7 +41,9 @@ export function activate(context: ExtensionContext) {
     }
   });
   workspace.onDidCloseTextDocument(() => {
-    statusBar.hide();
+    if (!window.activeTextEditor) {
+      statusBar.hide();
+    }
   });
   window.onDidChangeActiveTextEditor(e => {
     if (e) {
@@ -73,6 +75,11 @@ export function activate(context: ExtensionContext) {
 
         statusBar.text = `Coverage: ${lines.hit}/${lines.found} lines`;
         statusBar.show();
+      }
+    } else {
+      const activeTextEditor = window.activeTextEditor;
+      if (activeTextEditor && (activeTextEditor.document.uri.fsPath.toLowerCase() === file)) {
+        statusBar.text = "";
       }
     }
   }


### PR DESCRIPTION
Once you reach 100% coverage for a file, old diagnostics would stay until you modified it.