### PR TITLE
Remove greenkeeper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,17 +22,9 @@ before_install:
       /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
     fi
 
-  - yarn global add greenkeeper-lockfile@1
-
 install:
   - yarn install --frozen-lockfile --ignore-engines
   - yarn vscode:prepublish
 
-before_script:
-  - greenkeeper-lockfile-update
-
 script:
   - yarn test
-
-after_script:
-  - greenkeeper-lockfile-upload

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Code Coverage
 
-[![Greenkeeper badge](https://badges.greenkeeper.io/markis/vscode-code-coverage.svg)](https://greenkeeper.io/)
-
 Code coverage will put squiggly lines under functions, lines or code branches that are not covered by unit tests. And will list the uncovered lines under the problems window.
 
 ![Demo](images/demo.png)


### PR DESCRIPTION
> We’ll stop Greenkeeper’s operation as an independent service on June 3rd, 2020. For your dependency update needs, we have a brilliant alternative for you: Snyk. The team behind Greenkeeper have spent the past months working with them on next-generation dependency updates as a part of their open-source security product. We invite all of our users to migrate over: Snyk not only has a generous free plan for Open Source repos and small organisations, but also offers dev-friendly security features that Greenkeeper didn’t have. They’re good people, and your repos will be in competent and caring hands.

Sad to see greenkeeper go.