### PR TITLE
Fix basic functionality (Linux, TypeScript, nyc 15.1.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "icon": "images/icon.png",
   "license": "MIT",
   "engines": {
-    "vscode": "^1.41.0"
+    "vscode": "^1.44.0"
   },
   "repository": {
     "type": "git",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,7 +25,7 @@ export function activate(context: ExtensionContext) {
   const packageInfo = require(join(context.extensionPath, "package.json"));
   const diagnostics = languages.createDiagnosticCollection("coverage");
   const statusBar = window.createStatusBarItem();
-  const coverageByfile = new Map<string, Coverage>();
+  const coverageByFile = new Map<string, Coverage>();
 
   const config = workspace.getConfiguration("markiscodecoverage");
   const configSearchCriteria =
@@ -95,8 +95,8 @@ export function activate(context: ExtensionContext) {
       return;
     }
     const file: string = activeTextEditor.document.uri.fsPath.toLowerCase();
-    if (coverageByfile.has(file)) {
-      const coverage = coverageByfile.get(file);
+    if (coverageByFile.has(file)) {
+      const coverage = coverageByFile.get(file);
       if (coverage) {
         const { lines } = coverage;
 
@@ -109,9 +109,9 @@ export function activate(context: ExtensionContext) {
   }
 
   function recordFileCoverage(coverages: CoverageCollection) {
-    coverageByfile.clear();
+    coverageByFile.clear();
     for (const coverage of coverages) {
-      coverageByfile.set(coverage.file.toLowerCase(), coverage);
+      coverageByFile.set(coverage.file.toLowerCase(), coverage);
     }
     showStatus();
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -80,7 +80,7 @@ export function activate(context: ExtensionContext) {
     workspace.findFiles(searchPattern).then((files) => {
       for (const file of files) {
         parseLcov(file.fsPath).then((coverages) => {
-          recordFileCoverage(coverages);
+          recordFileCoverage(coverages, workspaceFolder.uri.fsPath);
           convertDiagnostics(coverages, workspaceFolder.uri.fsPath);
         });
       }
@@ -108,10 +108,18 @@ export function activate(context: ExtensionContext) {
     }
   }
 
-  function recordFileCoverage(coverages: CoverageCollection) {
+  function recordFileCoverage(
+    coverages: CoverageCollection,
+    workspaceFolder: string | undefined
+  ) {
     coverageByFile.clear();
     for (const coverage of coverages) {
-      coverageByFile.set(coverage.file, coverage);
+      const fileName =
+        !isAbsolute(coverage.file) && workspaceFolder
+          ? join(workspaceFolder, coverage.file)
+          : coverage.file;
+
+      coverageByFile.set(fileName, coverage);
     }
     showStatus();
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -94,7 +94,7 @@ export function activate(context: ExtensionContext) {
       statusBar.hide();
       return;
     }
-    const file: string = activeTextEditor.document.uri.fsPath.toLowerCase();
+    const file: string = activeTextEditor.document.uri.fsPath;
     if (coverageByFile.has(file)) {
       const coverage = coverageByFile.get(file);
       if (coverage) {
@@ -111,7 +111,7 @@ export function activate(context: ExtensionContext) {
   function recordFileCoverage(coverages: CoverageCollection) {
     coverageByFile.clear();
     for (const coverage of coverages) {
-      coverageByFile.set(coverage.file.toLowerCase(), coverage);
+      coverageByFile.set(coverage.file, coverage);
     }
     showStatus();
   }


### PR DESCRIPTION
This PR contains changes I needed to get the extension working in my environment (typescript, linux, coverage reports from nyc 15.x):

* Use an absolute path for setting an entry into `coverageByFile`, as an absolute path is used for querying that map.
  In the example project the coverage contains absolute paths, but that uses nyc ^11.0.3.
* Make `vsce package` work by aligning `engines.vscode` and the @types/vscode dependency
* (cosmetic) Rename `coverageByfile` to `coverageByFile`
* Avoid conflating paths that differ by case (XXX: This should be fine on windows as well, but I haven't tested that)

For me the example project I'm not sure whether this fixes/is related to #55; for me the example worked.

Btw: Nice extension, thanks for that!