### PR TITLE
enable coverage report for type shellscript

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "onLanguage:rust",
     "onLanguage:typescript",
     "onLanguage:typescriptreact",
+    "onLanguage:shellscript",
     "onLanguage:vb"
   ],
   "main": "./out/src/extension.js",


### PR DESCRIPTION
With `bashcov` and the following configuration for `simplecov` can you get coverage reports for you shell scripts.

```ruby
# gem install simplecov-lcov simplecov-console
require 'simplecov-lcov'
require 'simplecov-console'

SimpleCov.start do
    add_filter %r{^/.git}
end

# Monkeypatch
# https://github.com/fortissimo1997/simplecov-lcov/pull/25
if ! SimpleCov.respond_to?(:branch_coverage?)
    module SimpleCov
        def self.branch_coverage?
            false
        end
    end
end
SimpleCov::Formatter::LcovFormatter.config.report_with_single_file = true
SimpleCov::Formatter::LcovFormatter.config do |c|
    c.output_directory = 'coverage' # default: "coverage/lcov"
    c.lcov_file_name = 'lcov.info'

end

SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
    SimpleCov::Formatter::LcovFormatter,
    SimpleCov::Formatter::HTMLFormatter,
    SimpleCov::Formatter::Console
])
```