### PR TITLE
Implement true highlighting for uncovered LoC

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,26 @@
         "command": "code-coverage.show",
         "title": "Show Code Coverage"
       }
+    ],
+    "colors": [
+      {
+        "id": "markiscodecoverage.colorUncoveredLineRuler",
+        "description": "Decoration color for uncovered lines",
+        "defaults": {
+          "dark": "#FF7F27BF",
+          "light": "#FF7F27FF",
+          "highContrast": "#FF7F27FF"
+        }
+      },
+      {
+        "id": "markiscodecoverage.colorUncoveredLineText",
+        "description": "Decoration color for uncovered lines",
+        "defaults": {
+          "dark": "#FF7F2750",
+          "light": "#FF7F2750",
+          "highContrast": "#FF7F2750"
+        }
+      }
     ]
   },
   "eslintConfig": {

--- a/src/coverage-decorations.ts
+++ b/src/coverage-decorations.ts
@@ -7,19 +7,20 @@ import {
   Range,
   TextEditorDecorationType,
   OverviewRulerLane,
-  MarkdownString
+  MarkdownString,
 } from "vscode";
 
-const UNCOVERED_LINE_MESSAGE = "This line is missing code coverage."
+const UNCOVERED_LINE_MESSAGE = "This line is missing code coverage.";
 
 export interface CoverageDecoration {
-  readonly decorationType: TextEditorDecorationType,
-  readonly decorationOptions: DecorationOptions[]
+  readonly decorationType: TextEditorDecorationType;
+  readonly decorationOptions: DecorationOptions[];
 }
 
 export class CoverageDecorations extends Disposable {
   private _isDisposed = false;
-  private _decorationType: TextEditorDecorationType | undefined = CoverageDecorations._createDecorationType();
+  private _decorationType: TextEditorDecorationType | undefined =
+    CoverageDecorations._createDecorationType();
   private _fileCoverageDecorations = new Map<string, DecorationOptions[]>();
 
   get decorationType(): TextEditorDecorationType {
@@ -48,18 +49,20 @@ export class CoverageDecorations extends Disposable {
 
     this._fileCoverageDecorations.set(
       file.toString(),
-      this._mapDecorationOptions(diagnostics)
+      this._mapDecorationOptions(diagnostics),
     );
   }
 
   getDecorationsForFile(file: Uri): CoverageDecoration | undefined {
     this._checkDisposed();
-    const coverageDecorations = this._fileCoverageDecorations.get(file.toString());
+    const coverageDecorations = this._fileCoverageDecorations.get(
+      file.toString(),
+    );
 
     if (coverageDecorations !== undefined) {
       return {
         decorationType: this._decorationType as TextEditorDecorationType,
-        decorationOptions: coverageDecorations
+        decorationOptions: coverageDecorations,
       };
     }
 
@@ -78,20 +81,24 @@ export class CoverageDecorations extends Disposable {
     this._fileCoverageDecorations.clear();
   }
 
-  private _mapDecorationOptions(diagnostics: readonly Diagnostic[]): DecorationOptions[] {
+  private _mapDecorationOptions(
+    diagnostics: readonly Diagnostic[],
+  ): DecorationOptions[] {
     const makeDecoration = (start: number, end: number) => {
       return {
         hoverMessage: new MarkdownString(UNCOVERED_LINE_MESSAGE),
-        range: new Range(start, 1, end, 1)
+        range: new Range(start, 1, end, 1),
       };
     };
 
     // For a single diagnostic or none, create a single decoration or none.
     if (diagnostics.length <= 1) {
-      return diagnostics.map(diag => makeDecoration(diag.range.start.line, diag.range.end.line));
+      return diagnostics.map((diag) =>
+        makeDecoration(diag.range.start.line, diag.range.end.line),
+      );
     }
-    
-    // Instead of creating a decoration for each diagnostic, 
+
+    // Instead of creating a decoration for each diagnostic,
     //// create a decoration for each contiguous set of lines marked with diagnostics.
     let decorations: DecorationOptions[] = [];
     let start = diagnostics[0].range.start.line;
@@ -102,9 +109,12 @@ export class CoverageDecorations extends Disposable {
       }
 
       // If this a line number constitutes a segment, increase the end line number
-      if (diagnostics[i-1].range.end.line + 1 === diagnostics[i].range.start.line) {
+      if (
+        diagnostics[i - 1].range.end.line + 1 ===
+        diagnostics[i].range.start.line
+      ) {
         end = diagnostics[i].range.end.line;
-        if (i+1 < diagnostics.length) {
+        if (i + 1 < diagnostics.length) {
           continue;
         }
       }
@@ -115,7 +125,10 @@ export class CoverageDecorations extends Disposable {
       end = diagnostics[i].range.end.line;
 
       // If the very last diagnostic constitutes a point and is not part of any segment, create a decoration for it.
-      if (i+1 === diagnostics.length && decorations[decorations.length-1].range.end.line !== start) {
+      if (
+        i + 1 === diagnostics.length &&
+        decorations[decorations.length - 1].range.end.line !== start
+      ) {
         decorations.push(makeDecoration(start, end));
       }
     }
@@ -125,7 +138,7 @@ export class CoverageDecorations extends Disposable {
 
   private _checkDisposed() {
     if (this._isDisposed) {
-      throw new Error('illegal state - object is disposed');
+      throw new Error("illegal state - object is disposed");
     }
   }
 
@@ -133,8 +146,8 @@ export class CoverageDecorations extends Disposable {
     return window.createTextEditorDecorationType({
       isWholeLine: true,
       overviewRulerLane: OverviewRulerLane.Full,
-      overviewRulerColor: { id: 'markiscodecoverage.colorUncoveredLineRuler' },
-      backgroundColor: { id: 'markiscodecoverage.colorUncoveredLineText' }
+      overviewRulerColor: { id: "markiscodecoverage.colorUncoveredLineRuler" },
+      backgroundColor: { id: "markiscodecoverage.colorUncoveredLineText" },
     });
   }
 }

--- a/src/coverage-decorations.ts
+++ b/src/coverage-decorations.ts
@@ -1,0 +1,140 @@
+import {
+  window,
+  DecorationOptions,
+  Diagnostic,
+  Disposable,
+  Uri,
+  Range,
+  TextEditorDecorationType,
+  OverviewRulerLane,
+  MarkdownString
+} from "vscode";
+
+const UNCOVERED_LINE_MESSAGE = "This line is missing code coverage."
+
+export interface CoverageDecoration {
+  readonly decorationType: TextEditorDecorationType,
+  readonly decorationOptions: DecorationOptions[]
+}
+
+export class CoverageDecorations extends Disposable {
+  private _isDisposed = false;
+  private _decorationType: TextEditorDecorationType | undefined = CoverageDecorations._createDecorationType();
+  private _fileCoverageDecorations = new Map<string, DecorationOptions[]>();
+
+  get decorationType(): TextEditorDecorationType {
+    this._checkDisposed();
+
+    // will never be undefined if not disposed
+    return this._decorationType as TextEditorDecorationType;
+  }
+
+  constructor() {
+    // use dummy function for callOnDispose since dispose() will be overrided
+    super(() => true);
+  }
+
+  public override dispose(): void {
+    if (!this._isDisposed) {
+      this._fileCoverageDecorations.clear();
+      this._decorationType = undefined;
+
+      this._isDisposed = true;
+    }
+  }
+
+  addDecorationsForFile(file: Uri, diagnostics: readonly Diagnostic[]): void {
+    this._checkDisposed();
+
+    this._fileCoverageDecorations.set(
+      file.toString(),
+      this._mapDecorationOptions(diagnostics)
+    );
+  }
+
+  getDecorationsForFile(file: Uri): CoverageDecoration | undefined {
+    this._checkDisposed();
+    const coverageDecorations = this._fileCoverageDecorations.get(file.toString());
+
+    if (coverageDecorations !== undefined) {
+      return {
+        decorationType: this._decorationType as TextEditorDecorationType,
+        decorationOptions: coverageDecorations
+      };
+    }
+
+    return coverageDecorations;
+  }
+
+  removeDecorationsForFile(file: Uri): void {
+    this._checkDisposed();
+
+    this._fileCoverageDecorations.delete(file.toString());
+  }
+
+  clearAllDecorations(): void {
+    this._checkDisposed();
+
+    this._fileCoverageDecorations.clear();
+  }
+
+  private _mapDecorationOptions(diagnostics: readonly Diagnostic[]): DecorationOptions[] {
+    const makeDecoration = (start: number, end: number) => {
+      return {
+        hoverMessage: new MarkdownString(UNCOVERED_LINE_MESSAGE),
+        range: new Range(start, 1, end, 1)
+      };
+    };
+
+    // For a single diagnostic or none, create a single decoration or none.
+    if (diagnostics.length <= 1) {
+      return diagnostics.map(diag => makeDecoration(diag.range.start.line, diag.range.end.line));
+    }
+    
+    // Instead of creating a decoration for each diagnostic, 
+    //// create a decoration for each contiguous set of lines marked with diagnostics.
+    let decorations: DecorationOptions[] = [];
+    let start = diagnostics[0].range.start.line;
+    let end = diagnostics[0].range.end.line;
+    for (let i = 0; i < diagnostics.length; ++i) {
+      if (i === 0) {
+        continue;
+      }
+
+      // If this a line number constitutes a segment, increase the end line number
+      if (diagnostics[i-1].range.end.line + 1 === diagnostics[i].range.start.line) {
+        end = diagnostics[i].range.end.line;
+        if (i+1 < diagnostics.length) {
+          continue;
+        }
+      }
+
+      // Create decorations covering the found line segment
+      decorations.push(makeDecoration(start, end));
+      start = diagnostics[i].range.start.line;
+      end = diagnostics[i].range.end.line;
+
+      // If the very last diagnostic constitutes a point and is not part of any segment, create a decoration for it.
+      if (i+1 === diagnostics.length && decorations[decorations.length-1].range.end.line !== start) {
+        decorations.push(makeDecoration(start, end));
+      }
+    }
+
+    return decorations;
+  }
+
+  private _checkDisposed() {
+    if (this._isDisposed) {
+      throw new Error('illegal state - object is disposed');
+    }
+  }
+
+  private static _createDecorationType(): TextEditorDecorationType {
+    return window.createTextEditorDecorationType({
+      isWholeLine: true,
+      overviewRulerLane: OverviewRulerLane.Full,
+      overviewRulerColor: { id: 'markiscodecoverage.colorUncoveredLineRuler' },
+      backgroundColor: { id: 'markiscodecoverage.colorUncoveredLineText' }
+    });
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -70,7 +70,13 @@ export async function activate(context: ExtensionContext) {
     }
   }
 
-  context.subscriptions.push(diagnostics, coverageDecorations, statusBar, showCommand, hideCommand);
+  context.subscriptions.push(
+    diagnostics,
+    coverageDecorations,
+    statusBar,
+    showCommand,
+    hideCommand,
+  );
 
   // Update status bar on changes to any open file
   workspace.onDidChangeTextDocument((e) => {
@@ -108,7 +114,10 @@ export async function activate(context: ExtensionContext) {
     diagnostics.clear();
     coverageDecorations.clearAllDecorations();
     // Disable rendering of decorations in editor view
-    window.activeTextEditor?.setDecorations(coverageDecorations.decorationType, []);
+    window.activeTextEditor?.setDecorations(
+      coverageDecorations.decorationType,
+      [],
+    );
   }
 
   async function onShowCoverage() {
@@ -118,12 +127,14 @@ export async function activate(context: ExtensionContext) {
     // This ensures the decorations will show up again when switching back and forth between Show / Hide.
     const activeTextEditor = window.activeTextEditor;
     if (activeTextEditor !== undefined) {
-      const decorations = coverageDecorations.getDecorationsForFile(activeTextEditor.document.uri);
+      const decorations = coverageDecorations.getDecorationsForFile(
+        activeTextEditor.document.uri,
+      );
 
       if (decorations !== undefined) {
         const { decorationType, decorationOptions } = decorations;
         // Render decorations in editor view
-        activeTextEditor.setDecorations(decorationType, decorationOptions); 
+        activeTextEditor.setDecorations(decorationType, decorationOptions);
       }
     }
   }
@@ -158,13 +169,20 @@ export async function activate(context: ExtensionContext) {
       if (coverage) {
         const { lines } = coverage;
         // Only want to call setDecorations at most 2 times.
-        if (setDecorationsCounter < 2 ) {
-          let decorations = coverageDecorations.getDecorationsForFile(activeTextEditor.document.uri);
+        if (setDecorationsCounter < 2) {
+          let decorations = coverageDecorations.getDecorationsForFile(
+            activeTextEditor.document.uri,
+          );
 
           // If VSCode launches the workspace with already opened document, this ensures the decorations will appear along with the diagnostics.
           if (decorations === undefined) {
-            coverageDecorations.addDecorationsForFile(activeTextEditor.document.uri, diagnostics.get(activeTextEditor.document.uri) ?? []);
-            decorations = coverageDecorations.getDecorationsForFile(activeTextEditor.document.uri);
+            coverageDecorations.addDecorationsForFile(
+              activeTextEditor.document.uri,
+              diagnostics.get(activeTextEditor.document.uri) ?? [],
+            );
+            decorations = coverageDecorations.getDecorationsForFile(
+              activeTextEditor.document.uri,
+            );
           }
 
           if (decorations !== undefined) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -183,9 +183,7 @@ export async function activate(context: ExtensionContext) {
             decorations = coverageDecorations.getDecorationsForFile(
               activeTextEditor.document.uri,
             );
-          }
-
-          if (decorations !== undefined) {
+          } else {
             const { decorationType, decorationOptions } = decorations;
             activeTextEditor.setDecorations(decorationType, decorationOptions);
             setDecorationsCounter++;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -238,7 +238,7 @@ export async function activate(context: ExtensionContext) {
           coverageDecorations.addDecorationsForFile(file, diagnosticsForFiles);
         } else {
           const file = Uri.file(fileName);
-          diagnostics.delete(Uri.file(fileName));
+          diagnostics.delete(file);
           coverageDecorations.removeDecorationsForFile(file);
         }
       }

--- a/test/suite/extension.test.ts
+++ b/test/suite/extension.test.ts
@@ -33,12 +33,25 @@ suite("code-coverage", function () {
     commands.executeCommand("workbench.action.closeActiveEditor");
   });
 
+  this.afterEach = () => {
+    extension?.exports.coverageDecorations.clearAllDecorations();
+    return this;
+  };
+
   test("check diagnostics exist", async () => {
     // Check to see if the diagnostics exist for the example file
     // there should only be one line not covered, and so only one diagnostic should exist
     const diagnostics = languages.getDiagnostics(exampleIndexUri);
     assert.strictEqual(diagnostics.length, 1);
     assert.strictEqual(diagnostics[0].range.start.line, 5);
+  });
+
+  test("check decorations can be generated from diagnostics and retrieved", async () => {
+    const diagnostics = languages.getDiagnostics(exampleIndexUri);
+    extension?.exports.coverageDecorations.addDecorationsForFile(exampleIndexUri, diagnostics);
+    const decorationSpec = extension?.exports.coverageDecorations.getDecorationsForFile(exampleIndexUri);
+    assert.notEqual(decorationSpec, undefined);
+    assert.strictEqual(decorationSpec.decorationOptions.length, 1);
   });
 
   test("check status bar", async () => {

--- a/test/suite/extension.test.ts
+++ b/test/suite/extension.test.ts
@@ -48,8 +48,14 @@ suite("code-coverage", function () {
 
   test("check decorations can be generated from diagnostics and retrieved", async () => {
     const diagnostics = languages.getDiagnostics(exampleIndexUri);
-    extension?.exports.coverageDecorations.addDecorationsForFile(exampleIndexUri, diagnostics);
-    const decorationSpec = extension?.exports.coverageDecorations.getDecorationsForFile(exampleIndexUri);
+    extension?.exports.coverageDecorations.addDecorationsForFile(
+      exampleIndexUri,
+      diagnostics,
+    );
+    const decorationSpec =
+      extension?.exports.coverageDecorations.getDecorationsForFile(
+        exampleIndexUri,
+      );
     assert.notEqual(decorationSpec, undefined);
     assert.strictEqual(decorationSpec.decorationOptions.length, 1);
   });


### PR DESCRIPTION
# Implement true highlighting for uncovered LoC

This PR implements true highlighting for uncovered lines. It's more user-friendly and allows better visibility.

I wasn't too sure what to pick color-wise, so I picked an orange with a different alpha value for dark vs. light mode. It looks decent enough, I suppose.

Please review and let me know your thoughts.

#### Dark Mode
![screenshot](https://github.com/markis/vscode-code-coverage/assets/35634280/89f55261-5240-4c04-96ca-f4676a20ea4f)

#### Bright Mode
![screenshot2](https://github.com/markis/vscode-code-coverage/assets/35634280/cad198ab-6ae2-4f5d-933b-bb811a2cbd27)
