### PR TITLE
Indicate files below coverage threshold. Make Config Refreshable.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode-test
+example/.vscode
 example/.nyc_output
 example/coverage
 example/node_modules

--- a/package.json
+++ b/package.json
@@ -63,6 +63,13 @@
           "default": "coverage/lcov*.info",
           "description": "Search location for lcov files"
         },
+        "markiscodecoverage.coverageThreshold": {
+          "type": "number",
+          "default": 80,
+          "minimum": 0,
+          "maximum": 100,
+          "description": "The desired code coverage percentage ratio per-file"
+        },
         "markiscodecoverage.enableOnStartup": {
           "type": "boolean",
           "default": true,
@@ -101,6 +108,15 @@
           "dark": "#FF7F2750",
           "light": "#FF7F2750",
           "highContrast": "#FF7F2750"
+        }
+      },
+      {
+        "id": "markiscodecoverage.insufficientCoverageForeground",
+        "description": "Decoration color for files with insufficient coverage",
+        "defaults": {
+          "light": "#AD0707FF",
+          "dark": "#C74E39FF",
+          "highContrast": "#C74E39FF"
         }
       }
     ]

--- a/src/extension-configuration.ts
+++ b/src/extension-configuration.ts
@@ -1,0 +1,122 @@
+import {
+  ConfigurationChangeEvent,
+  Disposable,
+  Event,
+  EventEmitter,
+  WorkspaceConfiguration,
+} from "vscode";
+
+export const CONFIG_SECTION_NAME = "markiscodecoverage";
+export const CONFIG_OPTION_ENABLE_ON_STARTUP = "enableOnStartup";
+export const CONFIG_OPTION_SEARCH_CRITERIA = "searchCriteria";
+export const CONFIG_OPTION_COVERAGE_THRESHOLD = "coverageThreshold";
+
+export const DEFAULT_SEARCH_CRITERIA = "coverage/lcov*.info";
+export const DEFAULT_CODE_COVERAGE_THRESHOLD = 80;
+
+export class ExtensionConfiguration extends Disposable {
+  private readonly _onConfigOptionUpdated = new EventEmitter<string>();
+  private _isDisposed = false;
+  private _showCoverage = true;
+  private _searchCriteria = "";
+  private _coverageThreshold = 0;
+
+  constructor(config: WorkspaceConfiguration) {
+    // use dummy function for callOnDispose since dispose() will be overrided
+    super(() => true);
+
+    this.showCoverage =
+      !config.has(CONFIG_OPTION_ENABLE_ON_STARTUP) ||
+      (config.get(CONFIG_OPTION_ENABLE_ON_STARTUP) ?? true);
+
+    const configSearchCriteria =
+      config.has(CONFIG_OPTION_SEARCH_CRITERIA) &&
+      config.get(CONFIG_OPTION_SEARCH_CRITERIA);
+    this.searchCriteria =
+      configSearchCriteria && typeof configSearchCriteria === "string"
+        ? configSearchCriteria
+        : DEFAULT_SEARCH_CRITERIA;
+
+    this.coverageThreshold =
+      config.get(CONFIG_OPTION_COVERAGE_THRESHOLD) ??
+      DEFAULT_CODE_COVERAGE_THRESHOLD;
+  }
+
+  public override dispose(): void {
+    if (!this._isDisposed) {
+      this._onConfigOptionUpdated.dispose();
+
+      this._isDisposed = true;
+    }
+  }
+
+  get showCoverage() {
+    this._checkDisposed();
+    return this._showCoverage;
+  }
+  set showCoverage(value: boolean) {
+    this._checkDisposed();
+    this._showCoverage = value;
+  }
+
+  get searchCriteria() {
+    this._checkDisposed();
+    return this._searchCriteria;
+  }
+  set searchCriteria(value: string) {
+    this._checkDisposed();
+    this._searchCriteria = value;
+  }
+
+  get coverageThreshold() {
+    this._checkDisposed();
+    return this._coverageThreshold;
+  }
+  set coverageThreshold(value: number) {
+    this._checkDisposed();
+    this._coverageThreshold = value;
+  }
+
+  get onConfigOptionUpdated(): Event<string> {
+    this._checkDisposed();
+    return this._onConfigOptionUpdated.event;
+  }
+
+  dispatchConfigUpdate(
+    evtSrc: ConfigurationChangeEvent,
+    latestSnapshot: WorkspaceConfiguration,
+  ): void {
+    this._checkDisposed();
+
+    if (this._hasBeenUpdated(evtSrc, CONFIG_OPTION_SEARCH_CRITERIA)) {
+      const configSearchCriteria =
+        latestSnapshot.has(CONFIG_OPTION_SEARCH_CRITERIA) &&
+        latestSnapshot.get(CONFIG_OPTION_SEARCH_CRITERIA);
+      this.searchCriteria =
+        configSearchCriteria && typeof configSearchCriteria === "string"
+          ? configSearchCriteria
+          : this.searchCriteria;
+
+      this._onConfigOptionUpdated.fire(CONFIG_OPTION_SEARCH_CRITERIA);
+    } else if (this._hasBeenUpdated(evtSrc, CONFIG_OPTION_COVERAGE_THRESHOLD)) {
+      this.coverageThreshold =
+        latestSnapshot.get(CONFIG_OPTION_COVERAGE_THRESHOLD) ??
+        this.coverageThreshold;
+
+      this._onConfigOptionUpdated.fire(CONFIG_OPTION_COVERAGE_THRESHOLD);
+    }
+  }
+
+  private _hasBeenUpdated(
+    evtSrc: ConfigurationChangeEvent,
+    optionName: string,
+  ): boolean {
+    return evtSrc.affectsConfiguration(`${CONFIG_SECTION_NAME}.${optionName}`);
+  }
+
+  private _checkDisposed() {
+    if (this._isDisposed) {
+      throw new Error("illegal state - object is disposed");
+    }
+  }
+}

--- a/src/file-coverage-info-provider.ts
+++ b/src/file-coverage-info-provider.ts
@@ -1,0 +1,140 @@
+import {
+  CancellationToken,
+  Disposable,
+  Event,
+  EventEmitter,
+  FileDecoration,
+  FileDecorationProvider,
+  ProviderResult,
+  ThemeColor,
+  Uri,
+} from "vscode";
+import {
+  CONFIG_OPTION_COVERAGE_THRESHOLD,
+  ExtensionConfiguration,
+} from "./extension-configuration";
+import { Coverage } from "./coverage-info";
+import * as os from "node:os";
+
+const isWindows = () => os.type() === "Windows_NT";
+
+const FILE_DECORATION_BADGE = "<%";
+const FILE_DECORATION_TOOLTIP_PRELUDE = "Insufficent Code Coverage:";
+
+export class FileCoverageInfoProvider
+  extends Disposable
+  implements FileDecorationProvider
+{
+  private readonly _onDidChangeFileDecorations = new EventEmitter<
+    Uri | Uri[] | undefined
+  >();
+  private readonly _coverageByFile: Map<string, Coverage>;
+  private _listener: Disposable;
+  private _isDisposed = false;
+  private _showFileDecorations = true;
+  private _coverageThreshold = 0;
+
+  constructor(
+    readonly configuration: ExtensionConfiguration,
+    readonly coverageByFile: Map<string, Coverage>,
+  ) {
+    // use dummy function for callOnDispose since dispose() will be overrided
+    super(() => true);
+
+    this._coverageByFile = coverageByFile;
+    this._coverageThreshold = configuration.coverageThreshold;
+
+    // Watch for updates to coverage threshold and regenerate when its updated
+    this._listener = configuration.onConfigOptionUpdated((e) => {
+      if (
+        e &&
+        e === CONFIG_OPTION_COVERAGE_THRESHOLD &&
+        configuration.coverageThreshold !== this._coverageThreshold
+      ) {
+        this._coverageThreshold = configuration.coverageThreshold;
+        this.changeFileDecorations(Array.from(this._coverageByFile.keys()));
+      }
+    });
+  }
+
+  public override dispose(): void {
+    if (!this._isDisposed) {
+      this._onDidChangeFileDecorations.dispose();
+      this._listener.dispose();
+
+      this._isDisposed = true;
+    }
+  }
+
+  // Toggle display of the decorations in Explore View
+  get showFileDecorations(): boolean {
+    this._checkDisposed();
+    return this._showFileDecorations;
+  }
+  set showFileDecorations(value: boolean) {
+    this._checkDisposed();
+    this._showFileDecorations = value;
+  }
+
+  // The event that window.registerFileDecorationProvider() subscribes to
+  get onDidChangeFileDecorations(): Event<Uri | Uri[] | undefined> {
+    this._checkDisposed();
+    return this._onDidChangeFileDecorations.event;
+  }
+
+  // Either decorates or undecorates a file within the Explore View
+  provideFileDecoration(
+    uri: Uri,
+    _token: CancellationToken,
+  ): ProviderResult<FileDecoration> {
+    this._checkDisposed();
+
+    if (!this.showFileDecorations) {
+      return;
+    }
+
+    let path = uri.fsPath;
+    // Uri.file() might lowercase the drive letter on some machines which might not match coverageByFile's keys
+    // Encountered this issue on a Windows 11 machine but not my main Windows 10 system...
+    if (!this._coverageByFile.has(path) && isWindows()) {
+      path = path.charAt(0).toUpperCase().concat(path.substring(1));
+    }
+
+    const coverage = this._coverageByFile.get(path);
+    if (coverage === undefined) {
+      return;
+    }
+
+    const { lines } = coverage;
+    const percentCovered = Math.floor((lines.hit / lines.found) * 100);
+
+    if (percentCovered < this._coverageThreshold) {
+      return new FileDecoration(
+        FILE_DECORATION_BADGE,
+        `${FILE_DECORATION_TOOLTIP_PRELUDE} ${percentCovered}% vs. ${this._coverageThreshold}%.`,
+        new ThemeColor("markiscodecoverage.insufficientCoverageForeground"),
+      );
+    }
+
+    return;
+  }
+
+  // Fire the onDidChangeFileDecorations event for the specified file(s)
+  changeFileDecorations(fsPaths: string | string[]): void {
+    this._checkDisposed();
+
+    if (typeof fsPaths === "string") {
+      this._onDidChangeFileDecorations.fire([Uri.file(fsPaths)]);
+    }
+
+    this._onDidChangeFileDecorations.fire(
+      (fsPaths as string[]).map((p) => Uri.file(p)),
+    );
+  }
+
+  private _checkDisposed() {
+    if (this._isDisposed) {
+      throw new Error("illegal state - object is disposed");
+    }
+  }
+}


### PR DESCRIPTION
# Indicate files below coverage threshold. Make Config Refreshable.

Here's another feature that I felt this extension was missing. I also fixed a bug. Although I've done my own manual testing and written test cases, I'd encourage you to take this for a spin.

In this PR:

-  File decorations for files with coverage below a configurable threshold, __default `80%`__, have been implemented. The badge that displays beside them has a tooltip detailing the actual vs desired coverage percentage. Changing the value in config will update the displayed file decorations in real-time.
- Configuration refactor to enable refreshable config. For the code coverage file decorations, it is real-time. For the coverage definition file specified by __`searchCriteria`__, the behavior is now the expected behavior as detailed in #90 . 

#### File Decorations
![screenshot3](https://github.com/markis/vscode-code-coverage/assets/35634280/19f9e5ed-1c37-4da8-846d-d130ae22ee9f)

#### Configuration Option
![screenshot4](https://github.com/markis/vscode-code-coverage/assets/35634280/305775fe-d1f8-4b36-a767-1e762665c59e)
